### PR TITLE
Update version of Powertools for AWS Lambda (Java) 

### DIFF
--- a/functions/java/modules/module1/pom.xml
+++ b/functions/java/modules/module1/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <powertools.version>1.17.0</powertools.version> <!-- TODO: upgrade when #1420 is released -->
+        <powertools.version>1.18.0</powertools.version>
         <httpclient.version>4.5.14</httpclient.version>
     </properties>
 

--- a/functions/java/modules/module1/src/main/java/com/amazonaws/powertools/workshop/Module1HandlerComplete.java
+++ b/functions/java/modules/module1/src/main/java/com/amazonaws/powertools/workshop/Module1HandlerComplete.java
@@ -49,7 +49,7 @@ public class Module1HandlerComplete implements RequestHandler<S3EBEvent, String>
         // Configure Idempotency module
         Idempotency.config().withConfig(
                         IdempotencyConfig.builder()
-                                .withEventKeyJMESPath("etag") // TODO: replace with [etag, userId] when #1419 is fixed
+                                .withEventKeyJMESPath("[etag, userId]")
                                 .withThrowOnNoIdempotencyKey(true)
                                 .withExpiration(Duration.ofMinutes(120))
                                 .build())
@@ -78,7 +78,6 @@ public class Module1HandlerComplete implements RequestHandler<S3EBEvent, String>
 
         // add metadata to the logs
         LoggingUtils.appendKey("S3Object", object.toString());
-        LoggingUtils.appendKey("XrayTraceId", AWSXRay.getCurrentSegment().getTraceId().toString());
 
         try {
             // Mark file as working
@@ -97,7 +96,6 @@ public class Module1HandlerComplete implements RequestHandler<S3EBEvent, String>
         } finally {
             // remove metadata for subsequent lambda executions
             LoggingUtils.removeKey("S3Object");
-            LoggingUtils.removeKey("XrayTraceId");
         }
 
         return "ok";

--- a/functions/java/modules/module2/pom.xml
+++ b/functions/java/modules/module2/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <powertools.version>1.17.0</powertools.version> <!-- TODO: upgrade when #1420 is released -->
+        <powertools.version>1.18.0</powertools.version>
     </properties>
 
     <dependencyManagement>

--- a/functions/java/modules/module3/pom.xml
+++ b/functions/java/modules/module3/pom.xml
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <powertools.version>1.17.0</powertools.version> <!-- TODO: upgrade when #1420 is released -->
+        <powertools.version>1.18.0</powertools.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
*Description of changes:*

Updating the workshop with version `1.18.0` Powertools for AWS Lambda (Java)
Also removing some workarounds that were put in place previously, for bugs that were fixed in the latest release


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
