### PR TITLE
infra(ide): updating instance type

### DIFF
--- a/functions/python/modules/module1/app.py
+++ b/functions/python/modules/module1/app.py
@@ -93,8 +93,6 @@ def lambda_handler(event, context):
         new_thumbnail_image = process_thumbnail(transform_image=transform_image)
 
         mark_file_as(file_id, FileStatus.DONE.value, new_thumbnail_image)
-
-        # ADD GRAPHQL API
     except Exception as exc:
         mark_file_as(file_id, FileStatus.FAIL.value)
         print("An unexpected error occurred")

--- a/functions/python/modules/module1/app_complete.py
+++ b/functions/python/modules/module1/app_complete.py
@@ -134,8 +134,6 @@ def lambda_handler(event, context: LambdaContext):
         metrics.add_metric(name="ImageProcessed", unit=MetricUnit.Count, value=1)
 
         mark_file_as(file_id, FileStatus.DONE.value, new_thumbnail_image)
-
-        # ADD GRAPHQL API
     except Exception as exc:
         mark_file_as(file_id, FileStatus.FAIL.value)
         logger.exception("An unexpected error occurred", log=exc)

--- a/functions/python/modules/module2/app.py
+++ b/functions/python/modules/module2/app.py
@@ -34,6 +34,7 @@ def record_handler(record: DynamoDBRecord):
     try:
         get_labels(S3_BUCKET_FILES, file_id, user_id, transformed_key)
     except (NoLabelsFoundError, NoPersonFoundError):
+        logger.warning("No person found in the image")
         api_url = json.loads(API_URL_HOST).get("url")
         api_key = get_secret_value(API_KEY_SECRET_NAME)
         if not api_key:

--- a/functions/python/modules/module2/app_complete.py
+++ b/functions/python/modules/module2/app_complete.py
@@ -22,7 +22,7 @@ logger = Logger()
 tracer = Tracer()
 
 S3_BUCKET_FILES = os.getenv("BUCKET_NAME_FILES", "")
-API_URL_HOST = os.getenv("API_URL_HOST", "")
+API_URL_PARAMETER_NAME = os.getenv("API_URL_PARAMETER_NAME", "")
 API_KEY_SECRET_NAME = os.getenv("API_KEY_SECRET_NAME", "")
 
 
@@ -54,7 +54,7 @@ def record_handler(record: DynamoDBRecord, lambda_context: LambdaContext):
             logger.warning("No person found in the image")
             # Get the apiUrl and apiKey
             # You can replace these with the actual values or retrieve them from a secret manager.
-            api_url = parameters.get_parameter(API_URL_HOST, transform="json", max_age=900)["url"]
+            api_url = parameters.get_parameter(API_URL_PARAMETER_NAME, transform="json", max_age=900)["url"]
             api_key = parameters.get_secret(API_KEY_SECRET_NAME)
             report_image_issue(file_id=file_id, user_id=user_id, api_key=api_key, api_url=api_url)
         except ImageDetectionError as error:

--- a/infra/lib/attendant-ide/compute-construct.ts
+++ b/infra/lib/attendant-ide/compute-construct.ts
@@ -166,9 +166,9 @@ export class ComputeConstruct extends Construct {
     this.instance = new Instance(this, 'ide-instance', {
       vpc,
       vpcSubnets: { subnetType: SubnetType.PUBLIC },
-      instanceType: new InstanceType('c6g.large'),
+      instanceType: new InstanceType('c5.large'),
       machineImage: MachineImage.fromSsmParameter(
-        '/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64'
+        '/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64'
       ),
       blockDevices: [
         {


### PR DESCRIPTION
Hello @dreamorosi! I ran into a problem running `LANGUAGE=python npm run infra:deployHot` on arm64 architectures. I need to inspect further, but the CDK is unable to "build" the Python application due to some python libraries that uses a glibc older than AL2023, and it's blocking to deploy changes from VSCODE-BROWSER. Do you think it's ok to upgrade the instance to run the x86_64 kernel? I don't see any impact on node/java/dotnet.

By submitting this pull request, I confirm that you may use, modify, copy and redistribute this contribution under the terms of your choosing.