### PR TITLE
fix: lambda functions runtime bump to java21

### DIFF
--- a/infra/lib/constants.ts
+++ b/infra/lib/constants.ts
@@ -43,7 +43,7 @@ export const commonNodeJsBundlingSettings: Partial<NodeBundlingOptions> = {
 };
 
 export const commonJavaFunctionSettings: Partial<FunctionProps> = {
-  runtime: Runtime.JAVA_17,
+  runtime: Runtime.JAVA_21,
   tracing: Tracing.ACTIVE,
   logRetention: RetentionDays.FIVE_DAYS,
   timeout: Duration.seconds(30),
@@ -51,7 +51,7 @@ export const commonJavaFunctionSettings: Partial<FunctionProps> = {
 };
 
 export const commonJavaBundlingSettings: BundlingOptions = {
-  image: Runtime.JAVA_17.bundlingImage,
+  image: Runtime.JAVA_21.bundlingImage,
   command: [
     '/bin/sh',
     '-c',

--- a/infra/lib/image-detection/functions-construct.ts
+++ b/infra/lib/image-detection/functions-construct.ts
@@ -71,7 +71,7 @@ export class FunctionsConstruct extends Construct {
       this.imageDetectionFn = new Function(this, resourcePhysicalId, {
         ...commonJavaFunctionSettings,
         functionName,
-        runtime: Runtime.JAVA_17,
+        runtime: Runtime.JAVA_21,
         environment: {
           ...localEnvVars,
           POWERTOOLS_LOG_LEVEL: powertoolsLoggerLogLevel, // different from typescript

--- a/infra/lib/reporting-service/functions-construct.ts
+++ b/infra/lib/reporting-service/functions-construct.ts
@@ -67,7 +67,7 @@ export class FunctionsConstruct extends Construct {
       this.apiEndpointHandlerFn = new Function(this, resourcePhysicalId, {
         ...commonJavaFunctionSettings,
         functionName,
-        runtime: Runtime.JAVA_17,
+        runtime: Runtime.JAVA_21,
         environment: {
           ...localEnvVars,
           POWERTOOLS_LOG_LEVEL: powertoolsLoggerLogLevel, // different from typescript

--- a/infra/lib/thumbnail-generator/functions-construct.ts
+++ b/infra/lib/thumbnail-generator/functions-construct.ts
@@ -73,7 +73,7 @@ export class FunctionsConstruct extends Construct {
       this.thumbnailGeneratorFn = new Function(this, resourcePhysicalId, {
         ...commonJavaFunctionSettings,
         functionName,
-        runtime: Runtime.JAVA_17,
+        runtime: Runtime.JAVA_21,
         environment: {
           ...localEnvVars,
           POWERTOOLS_LOG_LEVEL: powertoolsLoggerLogLevel, // different from typescript


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/powertools-for-aws-lambda-workshop/issues/44

*Description of changes:*

All Lambda functions using Java are updated to use java 21.
This change has been tested, and the deployment completes successfully now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
