### PR TITLE
chore(ci): run cdk_nag only in ci; add scheduled workflow

### DIFF
--- a/.github/workflows/scheduled_check_infra.yml
+++ b/.github/workflows/scheduled_check_infra.yml
@@ -1,0 +1,40 @@
+name: Scheduled check infrastructure
+
+# PROCESS
+#
+# This workflow is run on a scheduled basis to check that the infrastructure stack and the IDE stack are compliant with the cdk_nag rules.
+#
+# 1. Setup codebase and dependencies
+# 2. Run the CDK synth command to generate the CloudFormation template for the infrastructure stack
+# 3. Run the CDK synth command to generate the CloudFormation template for the IDE stack
+
+# USAGE
+#
+# NOTE: meant to use as a scheduled task only (or manually for debugging purposes).
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 * 1/7 * *'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch_token:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
+      - name: Setup NodeJS
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Setup dependencies
+        run: npm ci
+      - name: Synth infrastructure
+        run: npm run infra:synth -- --c CI=true
+      - name: Synth IDE stack
+        run: npm run ide:synth -- --c CI=true

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -7,7 +7,11 @@ import { powertoolsServiceName, environment } from '../lib/constants';
 import { AwsSolutionsChecks } from 'cdk-nag';
 
 const app = new App();
-Aspects.of(app).add(new AwsSolutionsChecks());
+const isCI = app.node.tryGetContext('CI') === 'true' ? true : false;
+if (isCI) {
+  console.log('Running in CI/CD mode');
+  Aspects.of(app).add(new AwsSolutionsChecks());
+}
 new InfraStack(app, 'powertoolsworkshopinfra', {
   tags: {
     Service: powertoolsServiceName,


### PR DESCRIPTION
*Issue #, if available:* #52

*Description of changes:*

This PR changes the code in `infra/bin/infra.ts` so that CDK nag is ran only when the `CI` [context variable](https://docs.aws.amazon.com/cdk/v2/guide/get_context_var.html) is set to `true`.

This allows us to remove the `AwsSolutionsChecks` aspect when running the workshop but still maintain the ability to run it selectively.

The PR also adds a scheduled workflow that runs every ~7 days to check that the infrastructure is still compliant with the checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
