### PR TITLE
chore: add deploy all npm command for byoa

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ide:destroy": "npm run cdk:destroy -w infra -- powertoolsworkshopide",
     "ide:synth": "npm run cdk:synth-dev -w infra -- powertoolsworkshopide",
     "ide:wsPrep": "npm run convertCDKtoCfn -w scripts -- powertoolsworkshopide",
+    "workshop:deploy": "npm run cdk:deploy -w infra -- --all",
     "utils:createConfig": "npm run createConfig -w scripts",
     "utils:downloadFfmpegToLayer": "sh scripts/download-ffmpeg-to-layer.sh",
     "utils:convertCDKtoCfn": "npm run convertCDKtoCfn -w scripts"


### PR DESCRIPTION
*Issue #, if available:* #74

*Description of changes:*

This PR adds a new npm script that deploys both the infra and IDE stacks to an AWS account.

This is used mainly for the "Bring your own account" track of the workshop, but can be also used during development.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
